### PR TITLE
Significantly nicer error handling with context for the user

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +73,11 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cfg-if"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "clap"
 version = "2.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +97,25 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "build_const 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -132,6 +177,11 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,9 +195,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "strsim"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "termion"
@@ -183,10 +265,16 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unicode-xid"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unzipr"
 version = "0.3.1"
 dependencies = [
  "clap 2.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zip 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -240,13 +328,18 @@ dependencies = [
 "checksum adler32 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6cbd0b9af8587c72beadc9f72d35b9fbb070982c9e6203e46e93f10df25f8f45"
 "checksum ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6b3568b48b7cefa6b8ce125f9bb4989e52fbcc29ebea88df04cc7c5f12f70455"
 "checksum atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8352656fd42c30a0c3c89d26dea01e3b77c0ab2af18230835c15e2e13cd51859"
+"checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
+"checksum backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "bff67d0c06556c0b8e6b5f090f0eac52d950d9dfd1d35ba04e4ca3543eaf6a7e"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum build_const 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e90dc84f5e62d2ebe7676b83c22d33b6db8bd27340fb6ffbff0a364efa0cb9c9"
 "checksum bzip2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3eafc42c44e0d827de6b1c131175098fe7fb53b8ce8a47e65cb3ea94688be24"
 "checksum bzip2-sys 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2c5162604199bbb17690ede847eaa6120a3f33d5ab4dcc8e7c25b16d849ae79b"
 "checksum cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "deaf9ec656256bb25b404c51ef50097207b9cbb29c933d31f92cae5a8a0ffee0"
+"checksum cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efe5c877e17a9c717a0bf3613b2709f723202c4e4675cc8f12926ded29bcb17e"
 "checksum clap 2.29.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7b8f59bcebcfe4269b09f71dab0da15b355c75916a8f975d3876ce81561893ee"
 "checksum crc 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd5d02c0aac6bd68393ed69e00bbc2457f3e89075c6349db7189618dc4ddc1d7"
+"checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
+"checksum failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b"
 "checksum flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9fac2277e84e5e858483756647a9d0aa8d9a2b7cba517fd84325a0aaa69a0909"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1e5d97d6708edaa407429faa671b942dc0f2727222fb6b6539bf1db936e4b121"
@@ -254,13 +347,19 @@ dependencies = [
 "checksum miniz_oxide_c_api 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "92d98fdbd6145645828069b37ea92ca3de225e000d80702da25c20d3584b38a5"
 "checksum msdos_time 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "65ba9d75bcea84e07812618fedf284a64776c2f2ea0cad6bca7f69739695a958"
 "checksum podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd"
+"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "76d7ba1feafada44f2d38eed812bd2489a03c0f5abb975799251518b68848649"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
+"checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+"checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
 "checksum time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "a15375f1df02096fb3317256ce2cee6a1f42fc84ea5ad5fc8c421cfe40c73098"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
+"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ path = "src/mod.rs"
 [dependencies]
 clap = "2.29.4"
 zip = "0.3.0"
+failure = "0.1.1"

--- a/integration-tests.sh
+++ b/integration-tests.sh
@@ -69,7 +69,7 @@ assert_success_code $code
 echo "Running test 4"
 output=`$binary -l tests/resources/test.txt`
 code=$?
-expected="File is not a zip file"
+expected="File 'tests/resources/test.txt' is not a zip archive"
 
 assert_eq "$expected" "$output"
 assert_failure_code $code
@@ -80,7 +80,7 @@ assert_failure_code $code
 echo "Running test 5"
 output=`$binary -l tests/resources/asdf`
 code=$?
-expected="Input file does not exist"
+expected="No such file or directory 'tests/resources/asdf'"
 
 assert_eq "$expected" "$output"
 assert_failure_code $code
@@ -152,7 +152,7 @@ output=`$binary -d $test_dir tests/resources/test-test.zip test.zip`
 output=`$binary -d $test_dir tests/resources/test-test.zip test.zip`
 code=$?
 
-assert_eq "Target file already exists" "$output"
+assert_eq "Unpack target 'target/tests/test9/test/test.txt' already exists" "$output"
 assert_failure_code $code
 
 
@@ -166,6 +166,6 @@ mkdir -p $test_dir
 output=`$binary -d $test_dir tests/resources/asdf`
 code=$?
 
-assert_eq "Input file does not exist" "$output"
+assert_eq "No such file or directory 'tests/resources/asdf'" "$output"
 assert_failure_code $code
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,80 @@
+use failure::{Context, Fail};
+use std::fmt::{self, Display};
+use std::io::Error as IoError;
+
+#[derive(Clone, Debug, Fail, PartialEq)]
+pub enum ErrorKind {
+    #[fail(display = "File '{}' is not a zip archive", _0)]
+    NotZipArchive(String),
+
+    #[fail(display = "Zip archive does not contain entry '{}'", _0)]
+    ZipFileEntryNotFound(String),
+
+    #[fail(display = "Zip entry '{}' is not a zip archive", _0)]
+    ZipEntryNotZipArchive(String),
+
+    #[fail(display = "No such file or directory '{}'", _0)]
+    DoesNotExist(String),
+
+    #[fail(display = "IO error: {}", _0)]
+    IoError(String),
+
+    #[fail(display = "No nested target file provided for unpack. \
+    Please provide a nested file you want to unpack")]
+    UnpackTargetMissing,
+
+    #[fail(display = "Failed to create directory '{}'", _0)]
+    CannotCreateDirectory(String),
+
+    #[fail(display = "Cannot create file '{}'", _0)]
+    CannotCreateFile(String),
+
+    #[fail(display = "Cannot set permission '{}' for file '{}'", _0, _1)]
+    CannotSetPermissions(u32, String),
+
+    #[fail(display = "Unpack target '{}' already exists", _0)]
+    TargetAlreadyExists(String)
+}
+
+#[derive(Debug, Fail)]
+pub struct Error {
+    inner: Context<ErrorKind>,
+}
+
+impl Error {
+    #[cfg(test)]
+    pub fn kind(&self) -> ErrorKind {
+        self.inner.get_context().clone()
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&self.inner, f)
+    }
+}
+
+impl From<ErrorKind> for Error {
+    fn from(error_kind: ErrorKind) -> Error {
+        Error {
+            inner: Context::new(error_kind)
+        }
+    }
+}
+
+impl From<Context<ErrorKind>> for Error {
+    fn from(inner: Context<ErrorKind>) -> Error {
+        Error {
+            inner
+        }
+    }
+}
+
+impl From<IoError> for Error {
+    fn from(io_error: IoError) -> Error {
+        let error_string = io_error.to_string();
+        Error {
+            inner: io_error.context(ErrorKind::IoError(error_string))
+        }
+    }
+}

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,5 +1,5 @@
 use common::*;
-
+use error::Error;
 use std::rc::Rc;
 
 pub struct ListActionInput {
@@ -8,27 +8,27 @@ pub struct ListActionInput {
 }
 
 impl ListActionInput {
-    pub fn new(input: Vec<&str>) -> Result<Box<Action>> {
+    pub fn new(input: Vec<&str>) -> Result<Box<Action>, Error> {
         let (input_file, nested_files) = input.as_slice().split_first().unwrap();
-        return Ok(Box::new(ListActionInput {
+
+        let action_input = ListActionInput {
             input_file_name: input_file.to_string(),
             nested_file_names: nested_files.iter()
                 .map(|x| x.to_string())
                 .collect::<Vec<String>>(),
-        }));
+        };
+
+        Ok(Box::new(action_input))
     }
 }
 
 impl Action for ListActionInput {
-    fn exec(&self) -> Result<()> {
-        let mut inner_archive = match parse_file_to_archive(&self.input_file_name, &self.nested_file_names) {
-            Err(e) => return Err(e),
-            Ok(val) => val
-        };
-        for file_name in get_files_list(Rc::get_mut(&mut inner_archive).unwrap()) {
+    fn exec(&self) -> Result<(), Error> {
+        let mut inner_archive = parse_file_to_archive(&self.input_file_name, &self.nested_file_names)?;
+        for file_name in get_files_list(Rc::get_mut(&mut inner_archive).unwrap())? {
             println!("{}", file_name);
         }
-        return Ok(());
+        Ok(())
     }
 }
 

--- a/src/mod.rs
+++ b/src/mod.rs
@@ -1,14 +1,18 @@
 extern crate clap;
 extern crate zip;
+#[macro_use]
+extern crate failure;
 
 use clap::{Arg, App};
 
+mod error;
 mod common;
 mod list;
 mod pipe;
 mod unpack;
 
-use common::{Action, Result};
+use error::Error;
+use common::Action;
 use list::ListActionInput;
 use pipe::PipeUnpackActionInput;
 use unpack::UnpackActionInput;
@@ -46,7 +50,7 @@ pub fn main() {
     let pipe = matches.is_present("pipe");
     let files: Vec<&str> = matches.values_of("files").unwrap().collect();
 
-    let action: Result<Box<Action>>;
+    let action: Result<Box<Action>, Error>;
     if list {
         action = ListActionInput::new(files.clone());
     } else if pipe {
@@ -70,7 +74,7 @@ pub fn main() {
     };
 }
 
-fn unwrap_process_result(msg: &'static str) {
+fn unwrap_process_result(msg: Error) {
     println!("{}", msg);
     std::process::exit(1);
 }


### PR DESCRIPTION
I felt like error handling in this project was a real mess with strings scattered around everywhere.

In this PR I start using [failure](https://boats.gitlab.io/failure/error-errorkind.html) which provides a way to use enums to differentiate error kinds and allows to attach a user facing output for every error kind through context.

There are significantly less match statements related to error handling - should be easier to read.

Now the errors also provide context on for example which file failed to unpack etc.